### PR TITLE
Use absl::optional instead of std::optional

### DIFF
--- a/ntt_parameters.h
+++ b/ntt_parameters.h
@@ -168,7 +168,7 @@ struct NttParameters {
   ~NttParameters() = default;
 
   int number_coeffs;
-  std::optional<ModularInt> n_inv_ptr;
+  absl::optional<ModularInt> n_inv_ptr;
   std::vector<ModularInt> psis_bitrev;
   std::vector<ModularInt> psis_inv_bitrev;
   std::vector<unsigned int> bitrevs;


### PR DESCRIPTION
Currently, that's the only occurrence in the library where its using
std::optional instead of absl::optional. Therefore, for consistency
reasons, it's preferred to use absl::optional instead.