### PR TITLE
Alternative modular inverse using extended euclidean

### DIFF
--- a/shell_encryption/BUILD
+++ b/shell_encryption/BUILD
@@ -187,6 +187,7 @@ cc_library(
         "//shell_encryption/prng",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/numeric:int128",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],
 )


### PR DESCRIPTION
- This modular inversion doesn't assume the modulus is a prime.
- Also fix a potential signed integer overflow in multiplication.
- Note: Modular inversion using extended euclidean is not constant time, so it should not be used on key materials or ciphertexts.
- 