### PR TITLE
Remove int256 operator<< test for showbase with 0

### DIFF
--- a/shell_encryption/int256_test.cc
+++ b/shell_encryption/int256_test.cc
@@ -540,10 +540,6 @@ TEST(Int256, OStream) {
       {uint256(1), std::ios::dec | std::ios::showbase, 0, '_', "1"},
       {uint256(1), std::ios::oct | std::ios::showbase, 0, '_', "01"},
       {uint256(1), std::ios::hex | std::ios::showbase, 0, '_', "0x1"},
-      // showbase does nothing on zero
-      {uint256(0), std::ios::dec | std::ios::showbase, 0, '_', "0"},
-      {uint256(0), std::ios::oct | std::ios::showbase, 0, '_', "0"},
-      {uint256(0), std::ios::hex | std::ios::showbase, 0, '_', "0"},
       // showpos does nothing on unsigned types
       {uint256(1), std::ios::dec | std::ios::showpos, 0, '_', "1"},
       // padding


### PR DESCRIPTION
Upsteam libc++ is now also showing the octal `0` and hex `0x` prefixes with zero, see
https://github.com/llvm/llvm-project/pull/120859

These tests were failing with upstream libc++. The previous three lines test this enough; just remove the tests that now have inconsistent output across C++ standard libraries.